### PR TITLE
Install LaTeX styles

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ install_requires =
 
 [options.packages.find]
 exclude =
-    *test
+    *tests
 
 [options.package_data]
 submitty_arc.utils = latex_template/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,9 @@ install_requires =
 exclude =
     *test
 
+[options.package_data]
+submitty_arc.utils = latex_template/*
+
 [options.entry_points]
 console_scripts =
     grades-extractor = submitty_arc.instructor.grades_extractor:run_it


### PR DESCRIPTION
Fixes #1 and also (what I think was) a typo when excluding the tests.

I tried to change to the newer way of retrieving the path to the LaTeX styles (using `importlib.resources` instead of `__file__`) but I couldn't find a clean way without referring to an individual file. It seems unlikely that the current way will be a problem, anyway.