### PR TITLE
Fixes for mark deductions

### DIFF
--- a/submitty_arc/instructor/combine_grades.py
+++ b/submitty_arc/instructor/combine_grades.py
@@ -127,8 +127,8 @@ class Assignment:
         self.Sections['Penalty'] = Section(penalty_section)
         q = self.Sections['Penalty'].Questions[1]
         q._conversion = 1
-        q.set_points(0, int(penalty[0]))
         q.add_comments(texify_comments([penalty[1]]))
+        q.set_points(0, float(penalty[0]))
 
     def load_results(self, auto, manual, penalty=None):
         auto_results = Auto_grad(auto)

--- a/submitty_arc/instructor/combine_grades.py
+++ b/submitty_arc/instructor/combine_grades.py
@@ -127,8 +127,8 @@ class Assignment:
         self.Sections['Penalty'] = Section(penalty_section)
         q = self.Sections['Penalty'].Questions[1]
         q._conversion = 1
-        q.add_comments(texify_comments([penalty[1]]))
         q.set_points(0, float(penalty[0]))
+        q.add_comments(penalty[1])
 
     def load_results(self, auto, manual, penalty=None):
         auto_results = Auto_grad(auto)


### PR DESCRIPTION
Addressing two issues that I came across:
- Penalties had to be integers, which has not been the case so far
- Code in markdown (`like this`) was misformatted in the .tex output because it was "texified" twice.